### PR TITLE
Added check for task deadline in COPS.compute_timout

### DIFF
--- a/src/base.toit
+++ b/src/base.toit
@@ -363,4 +363,7 @@ class COPS extends at.Command:
   // We use the deadline in the task to let the AT processor know that we can abort
   // the COPS operation by sending more AT commands.
   static compute_timeout -> Duration:
-    return min MAX_TIMEOUT (Duration --us=(task.deadline - Time.monotonic_us))
+    if task.deadline == null:
+      return MAX_TIMEOUT
+    else:
+      return min MAX_TIMEOUT (Duration --us=(task.deadline - Time.monotonic_us))


### PR DESCRIPTION
The check here will determine if the current task runs in a timeout context and sets the timeout based on this.
This fixes #4 for the stack trace provided.