### PR TITLE
Added is_powered_off check

### DIFF
--- a/src/base/base.toit
+++ b/src/base/base.toit
@@ -304,6 +304,8 @@ abstract class CellularBase implements Cellular:
   reset -> none:
   recover_modem -> none:
     power_off
+  is_powered_off -> bool?:
+    return null
 
   /**
   Called when the driver has connected.

--- a/src/base/cellular.toit
+++ b/src/base/cellular.toit
@@ -89,6 +89,8 @@ interface Cellular:
 
   on_aborted_command session/at.Session command/at.Command -> none
 
+  is_powered_off -> bool?
+
 class Operator:
   op/string
   rat/int?

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -169,8 +169,10 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
       if is_powered_off == false:
         logger.info "power off not complete, forcing power down"
         driver_.power_off
-      else if is_powered_off == null: logger.info "cannot determine power state, assuming it's correctly powered down"
-      else: logger.info "module is correctly powered off"
+      else if is_powered_off == null: 
+        logger.info "cannot determine power state, assuming it's correctly powered down"
+      else: 
+        logger.info "module is correctly powered off"
 
     finally:
       close_pins_

--- a/src/base/service.toit
+++ b/src/base/service.toit
@@ -89,6 +89,10 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
   abstract create_driver -> Cellular
       --logger/log.Logger
       --port/uart.Port
+      --rx/gpio.Pin?
+      --tx/gpio.Pin?
+      --rts/gpio.Pin?
+      --cts/gpio.Pin?
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?
@@ -156,6 +160,18 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
         rts_.configure --output
         rts_.set 0
       wait_for_quiescent_ rx_
+
+      // driver_.close sends AT+CPWROFF. If the session wasn't active, this can fail 
+      // and therefore we probe it's power state and force it to power down if needed.
+      // The routine is not implemented for all modems, in which case is_power_off will return null.
+      // Therefore, we explicitly check for false. 
+      is_powered_off := driver_.is_powered_off
+      if is_powered_off == false:
+        logger.info "power off not complete, forcing power down"
+        driver_.power_off
+      else if is_powered_off == null: logger.info "cannot determine power state, assuming it's correctly powered down"
+      else: logger.info "module is correctly powered off"
+
     finally:
       close_pins_
       apn_ = bands_ = rats_ = null
@@ -192,6 +208,10 @@ abstract class CellularServiceProvider extends ProxyingNetworkServiceProvider:
     driver := create_driver
         --logger=logger
         --port=port
+        --rx=rx_
+        --tx=tx_
+        --rts=rts_
+        --cts=cts_
         --power=power_
         --reset=reset_
         --baud_rates=uart_baud_rates

--- a/src/modules/quectel/bg96.toit
+++ b/src/modules/quectel/bg96.toit
@@ -26,6 +26,10 @@ class BG96Service extends CellularServiceProvider:
   create_driver -> cellular.Cellular
       --logger/log.Logger
       --port/uart.Port
+      --rx/gpio.Pin?
+      --tx/gpio.Pin?
+      --rts/gpio.Pin?
+      --cts/gpio.Pin?
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?:

--- a/src/modules/sequans/monarch.toit
+++ b/src/modules/sequans/monarch.toit
@@ -41,6 +41,10 @@ class MonarchService extends CellularServiceProvider:
   create_driver -> cellular.Cellular
       --logger/log.Logger
       --port/uart.Port
+      --rx/gpio.Pin?
+      --tx/gpio.Pin?
+      --rts/gpio.Pin?
+      --cts/gpio.Pin?
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?:

--- a/src/modules/ublox/sara_r4.toit
+++ b/src/modules/ublox/sara_r4.toit
@@ -26,6 +26,10 @@ class SaraR4Service extends CellularServiceProvider:
   create_driver -> cellular.Cellular
       --logger/log.Logger
       --port/uart.Port
+      --rx/gpio.Pin?
+      --tx/gpio.Pin?
+      --rts/gpio.Pin?
+      --cts/gpio.Pin?
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud_rates/List?:
@@ -46,10 +50,18 @@ class SaraR4 extends UBloxCellular:
     "+USOCLCFG": [0],
   }
 
+  rx/gpio.Pin?
+  tx/gpio.Pin?
+  rts/gpio.Pin?
+  cts/gpio.Pin?
   pwr_on/gpio.Pin?
   reset_n/gpio.Pin?
 
   constructor port/uart.Port logger/log.Logger
+      --.rx=null
+      --.tx=null
+      --.rts=null
+      --.cts=null
       --.pwr_on=null
       --.reset_n=null
       --uart_baud_rates/List

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -159,7 +159,7 @@ class SaraR5 extends UBloxCellular:
     // If the modem is powered up, RX will be high, and if it's powered down, it will be low (ensured by the pull-down).
     rx.configure --input --pull-down
 
-    // Run multiple checks of the pin state to ensure that it's not flickering
+    // Run multiple checks of the pin state to ensure that it's not flickering.
     all_low := true
     for i:=0; i<10; i++:
       if (rx.get == 1): all_low = false

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -164,7 +164,7 @@ class SaraR5 extends UBloxCellular:
     for i:=0; i<10; i++:
       if (rx.get == 1): all_low = false
 
-    // Reconfigure the RX pin as normal input
+    // Reconfigure the RX pin as normal input.
     rx.configure --input
     return all_low
   

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -161,8 +161,8 @@ class SaraR5 extends UBloxCellular:
 
     // Run multiple checks of the pin state to ensure that it's not flickering.
     all_low := true
-    for i:=0; i<10; i++:
-      if (rx.get == 1): all_low = false
+    8.repeat:
+      if all_low and rx.get == 1: all_low = false
 
     // Reconfigure the RX pin as normal input.
     rx.configure --input

--- a/src/modules/ublox/sara_r5.toit
+++ b/src/modules/ublox/sara_r5.toit
@@ -152,11 +152,16 @@ class SaraR5 extends UBloxCellular:
   is_powered_off -> bool?:
     if rx == null: return null
 
-    // On SARA-R5, the RXD pin (modem's uart output) is a push-pull pin which is idle high and active low.
-    // When the modem is powered up, this pin will be connected to the internal 1.8V rail, which is turned off during power down.
-    // Therefore, by momentarily configuring the pin with a pull-down on the host microcontroller, we can assess the modem's state
-    // by checking this pin - without waking the modem up again. 
-    // If the modem is powered up, RX will be high, and if it's powered down, it will be low (ensured by the pull-down).
+    // On SARA-R5, the RXD pin (modem's uart output) is a push-pull
+    // pin which is idle high and active low. When the modem is
+    // powered up, this pin will be connected to the internal 1.8V
+    // rail, which is turned off during power down. Therefore, by
+    // momentarily configuring the pin with a pull-down on the host
+    // microcontroller, we can assess the modem's state by checking
+    // this pin - without waking the modem up again. If the modem is
+    // powered up, RX will be high, and if it's powered down, it will
+    // be low (ensured by the pull-down).
+
     rx.configure --input --pull-down
 
     // Run multiple checks of the pin state to ensure that it's not flickering.


### PR DESCRIPTION
Implemented `is_powered_off` method for SARA-R5 modems.

With this, the driver can monitor the power state of the modem without using the AT command interface and therefore monitor it without risking to wake it up again.

The gpio instances of the `CellularServiceProvider` was passed down to cellular drivers to provide them direct access to pin states to realize this. All pins were passed down as it's different for each modem how the power state can be monitored (without using the AT commands interface).