### PR TITLE
Add SIM800L GSM/GPRS cellular driver

### DIFF
--- a/examples/package.lock
+++ b/examples/package.lock
@@ -1,7 +1,10 @@
 sdk: ^2.0.0-alpha.144
 prefixes:
+  cellular: ..
   http: pkg-http
 packages:
+  ..:
+    path: ..
   pkg-http:
     url: github.com/toitlang/pkg-http
     name: http

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -1,4 +1,6 @@
 dependencies:
+  cellular:
+    path: ..
   http:
     url: github.com/toitlang/pkg-http
     version: ^2.7.0

--- a/examples/sim800l-tcall.toit
+++ b/examples/sim800l-tcall.toit
@@ -3,21 +3,38 @@
 // be found in the EXAMPLES_LICENSE file.
 
 /**
-Wrapper for the SIM800L driver on the LilyGO T-Call board.
+Custom service provider for the SIM800L on the LilyGO T-Call board.
 
-The T-Call board has a power management IC (IP5306) that must be enabled
-  via GPIO 23 before the SIM800L module can be used.
+The T-Call board has a power management IC (IP5306) controlled by GPIO 23
+  that must be enabled before the SIM800L module can be used. This service
+  provider turns the power IC on when the network is opened and off when
+  it is closed, following the pattern from the Olimex PoE Ethernet example.
 
 Install as a container:
 $ jag container install sim800l examples/sim800l-tcall.toit
 */
 
 import gpio
-import cellular.modules.simcom.sim800l
+import net
+
+import cellular.modules.simcom.sim800l show Sim800lService
+
+class Sim800lTCallService extends Sim800lService:
+  power-control_/gpio.Pin? := null
+
+  open-network -> net.Interface:
+    power-control_ = gpio.Pin --output 23
+    power-control_.set 1
+    return super
+
+  close-network network/net.Interface -> none:
+    try:
+      super network
+    finally:
+      if power-control_:
+        power-control_.close
+        power-control_ = null
 
 main:
-  // Enable the board's power management IC.
-  power-control := gpio.Pin --output 23
-  power-control.set 1
-
-  sim800l.main
+  service := Sim800lTCallService
+  service.install

--- a/examples/sim800l-tcall.toit
+++ b/examples/sim800l-tcall.toit
@@ -1,0 +1,23 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the EXAMPLES_LICENSE file.
+
+/**
+Wrapper for the SIM800L driver on the LilyGO T-Call board.
+
+The T-Call board has a power management IC (IP5306) that must be enabled
+  via GPIO 23 before the SIM800L module can be used.
+
+Install as a container:
+$ jag container install sim800l examples/sim800l-tcall.toit
+*/
+
+import gpio
+import cellular.modules.simcom.sim800l
+
+main:
+  // Enable the board's power management IC.
+  power-control := gpio.Pin --output 23
+  power-control.set 1
+
+  sim800l.main

--- a/examples/sim800l.toit
+++ b/examples/sim800l.toit
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the EXAMPLES_LICENSE file.
+
+/**
+This example demonstrates how to use the SIM800L service and connect it to a
+  cellular network.
+
+To run this example using Jaguar, you'll first need to install the
+  module service on the device.
+
+For a LilyGO T-Call board, use the T-Call specific wrapper to handle
+  the board's power management IC:
+$ jag pkg install --project-root examples/
+$ jag container install sim800l examples/sim800l-tcall.toit
+$ jag run examples/sim800l.toit
+
+For other boards, install the base driver:
+$ jag container install sim800l src/modules/simcom/sim800l.toit
+*/
+
+import http
+import log
+import net.cellular
+
+main:
+  config ::= {
+    // Set to your SIM card's APN.
+    cellular.CONFIG-APN: "simbase",
+
+    // LilyGO T-Call SIM800L pinout.
+    cellular.CONFIG-UART-TX: 27,
+    cellular.CONFIG-UART-RX: 26,
+
+    cellular.CONFIG-POWER: [4, cellular.CONFIG-ACTIVE-HIGH],  // PWRKEY.
+    cellular.CONFIG-RESET: [5, cellular.CONFIG-ACTIVE-LOW],  // RST (active-low).
+
+    cellular.CONFIG-LOG-LEVEL: log.DEBUG-LEVEL,
+  }
+
+  logger := log.default.with-name "sim800l"
+  logger.info "opening network"
+  network := cellular.open config
+
+  try:
+    client := http.Client network
+    host := "www.google.com"
+    response := client.get host "/"
+
+    bytes := 0
+    elapsed := Duration.of:
+      while data := response.body.read:
+        bytes += data.size
+
+    logger.info "http get" --tags={"host": host, "size": bytes, "elapsed": elapsed}
+
+  finally:
+    network.close

--- a/src/base/at.toit
+++ b/src/base/at.toit
@@ -326,7 +326,7 @@ class Session:
         if is-exception: abort_ exception.value
 
     if result := processor_.wait-for-result command-deadline_:
-      if not ok-termination_.contains result.code.to-byte-array:
+      if not is-ok-termination_ result.code.to-byte-array:
         exception := result.exception
         on-error.call exception result
       return result
@@ -361,8 +361,30 @@ class Session:
         return
     logger_.with-level log.DEBUG-LEVEL: it.debug "<- *ignored* [URC] $urc $response"
 
+  /**
+  Checks whether the $line is a termination string.
+
+  Also handles prefixed terminations like "<id>, SEND OK" used by some
+    modules (e.g. SIM800L in multi-connection mode).
+  */
   is-terminating_ line/ByteArray:
-    return ok-termination_.contains line or error-termination_.contains line
+    return is-ok-termination_ line or is-error-termination_ line
+
+  is-ok-termination_ line/ByteArray -> bool:
+    if ok-termination_.contains line: return true
+    return is-prefixed-termination_ line ok-termination_
+
+  is-error-termination_ line/ByteArray -> bool:
+    if error-termination_.contains line: return true
+    return is-prefixed-termination_ line error-termination_
+
+  static is-prefixed-termination_ line/ByteArray terminations/List -> bool:
+    str := line.to-string-non-throwing
+    comma := str.index-of ", "
+    if comma >= 0:
+      suffix := (str.copy comma + 2).to-byte-array
+      return terminations.contains suffix
+    return false
 
   is-echo_ line/ByteArray:
     return line.size >= 3 and line[0] == 'A' and line[1] == 'T' and line[2] == '+'

--- a/src/base/at.toit
+++ b/src/base/at.toit
@@ -141,6 +141,7 @@ class Session:
   response-parsers_/Map ::= {:}
   ok-termination_/List ::= ["OK".to-byte-array]
   error-termination_/List ::= ["ERROR".to-byte-array]
+  on-unhandled-line_/Lambda? := null
 
   s3-data_/ByteArray
 
@@ -214,6 +215,21 @@ class Session:
   unregister-urc name/string:
     urc-handlers_.remove name
       --if-absent=: throw "urc not registered: $name"
+
+  /**
+  Sets a callback for non-URC plain lines.
+
+  Some modules send asynchronous responses that are not URCs (no "+" prefix).
+    For example, the SIM800L sends "<id>, CONNECT OK" after CIPSTART. These
+    lines can arrive at any time, including during other active commands.
+
+  The callback receives the line as a string and must return true if it
+    handled the line. When no command is active, unhandled lines are
+    silently discarded. When a command is active, unhandled lines are
+    added as plain-text responses.
+  */
+  on-unhandled-line= callback/Lambda?:
+    on-unhandled-line_ = callback
 
   /**
   Executes a `read` command with the $command-name.
@@ -407,7 +423,12 @@ class Session:
         logger_.with-level log.DEBUG-LEVEL: it.debug "<- $(%c data-marker) *no data*"
       else if c >= 32:
         if not command_:
-          reader_.skip-up-to s3
+          line := reader_.read-bytes-up-to s3
+          str := line.to-string-non-throwing
+          handled := on-unhandled-line_ and (on-unhandled-line_.call str)
+          if handled:
+            logger_.with-level log.DEBUG-LEVEL: it.debug "<- $str (unhandled)"
+          // Discard unhandled lines when no command is active.
         else:
           read-plain_
       else:
@@ -460,6 +481,14 @@ class Session:
     if is-echo_ line: return
     if is-terminating_ line:
       complete-command_ line.to-string
+      return
+
+    // Check if the callback handles this line (e.g., stray
+    // "<n>, CONNECT OK" that arrived during another command).
+    str := line.to-string-non-throwing
+    handled := on-unhandled-line_ and (on-unhandled-line_.call str)
+    if handled:
+      logger_.with-level log.DEBUG-LEVEL: it.debug "  (dispatched via callback)"
       return
 
     if command_:

--- a/src/modules/simcom/README.md
+++ b/src/modules/simcom/README.md
@@ -1,0 +1,85 @@
+# SIM800L Driver
+
+Driver for the SIMCom SIM800L GSM/GPRS (2G) module.
+
+## Hardware requirements
+
+The SIM800L operates at **3.7-4.2V** and can draw up to **2A** during
+transmission bursts. Make sure your power supply can handle this.
+
+- Do **not** power the module from the ESP32's 3.3V pin.
+- A LiPo battery (3.7V, 1200mAh+) or a 2A-capable DC-DC converter is recommended.
+- Some boards (like the LilyGO T-Call) include a power management IC.
+
+### Pin connections
+
+| SIM800L Pin | Description |
+|-------------|-------------|
+| VCC | 3.7-4.2V power supply |
+| GND | Ground |
+| TXD | Module transmit → ESP32 UART RX |
+| RXD | Module receive ← ESP32 UART TX |
+| RST | Active-low reset (pull low to reset) |
+| PWRKEY | Power toggle (pulse low >1s to toggle on/off) |
+
+## Usage
+
+### Installation
+
+Install the driver as a container on the device:
+
+```
+jag container install sim800l src/modules/simcom/sim800l.toit
+```
+
+### LilyGO T-Call board
+
+The T-Call board has a power management IC (IP5306) controlled by GPIO 23
+that must be enabled before the SIM800L module can be used. Install the
+T-Call wrapper instead:
+
+```
+jag pkg install --project-root examples/
+jag container install sim800l examples/sim800l-tcall.toit
+```
+
+**T-Call pinout:**
+
+| Function | GPIO |
+|----------|------|
+| UART TX | 27 |
+| UART RX | 26 |
+| RST | 5 |
+| PWRKEY | 4 |
+| POWER_ON | 23 |
+
+### Configuration
+
+```toit
+import net.cellular
+
+config ::= {
+  cellular.CONFIG-APN: "your-apn",
+  cellular.CONFIG-UART-TX: 27,
+  cellular.CONFIG-UART-RX: 26,
+  cellular.CONFIG-POWER: [4, cellular.CONFIG-ACTIVE-HIGH],   // PWRKEY
+  cellular.CONFIG-RESET: [5, cellular.CONFIG-ACTIVE-LOW],    // RST
+  cellular.CONFIG-LOG-LEVEL: log.INFO-LEVEL,
+}
+
+network := cellular.open config
+```
+
+### Example
+
+See [examples/sim800l.toit](../../../examples/sim800l.toit) for a complete
+example that does an HTTP GET over the cellular network.
+
+## Limitations
+
+- 2G (GSM/GPRS) only — no LTE support.
+- Maximum 6 simultaneous TCP/UDP connections.
+- Maximum ~1460 bytes per send operation.
+- No hardware flow control (RTS/CTS) support in most configurations.
+- The PWRKEY pin toggles power on/off, so the driver only pulses it once
+  during initialization to avoid toggling the module off.

--- a/src/modules/simcom/README.md
+++ b/src/modules/simcom/README.md
@@ -7,9 +7,12 @@ Driver for the SIMCom SIM800L GSM/GPRS (2G) module.
 The SIM800L operates at **3.7-4.2V** and can draw up to **2A** during
 transmission bursts. Make sure your power supply can handle this.
 
-- Do **not** power the module from the ESP32's 3.3V pin.
+- Do **not** power the module from the ESP32's 3.3V or 5V pins. The 3.3V is
+  too low, and 5V exceeds the module's maximum voltage rating.
 - A LiPo battery (3.7V, 1200mAh+) or a 2A-capable DC-DC converter is recommended.
 - Some boards (like the LilyGO T-Call) include a power management IC.
+- The SIM800L uses ~2.8V logic levels. The ESP32's 3.3V TX cannot be connected
+  directly to the SIM800L RX — use a voltage divider or level shifter.
 
 ### Pin connections
 
@@ -35,8 +38,10 @@ jag container install sim800l src/modules/simcom/sim800l.toit
 ### LilyGO T-Call board
 
 The T-Call board has a power management IC (IP5306) controlled by GPIO 23
-that must be enabled before the SIM800L module can be used. Install the
-T-Call wrapper instead:
+that must be enabled before the SIM800L module can be used. The T-Call
+example provides a custom service provider that manages the power IC
+automatically — it enables the IC when the network is opened and disables
+it when all clients disconnect. Install the T-Call wrapper instead:
 
 ```
 jag pkg install --project-root examples/
@@ -78,8 +83,11 @@ example that does an HTTP GET over the cellular network.
 ## Limitations
 
 - 2G (GSM/GPRS) only — no LTE support.
-- Maximum 6 simultaneous TCP/UDP connections.
-- Maximum ~1460 bytes per send operation.
+- Maximum 6 simultaneous TCP/UDP connections. Opening a 7th connection
+  throws a `ResourceExhaustedException`.
+- Maximum ~1460 bytes per single AT send command. TCP writes are
+  automatically chunked by the driver; UDP sends that exceed the MTU
+  (1460 bytes) throw an error.
 - No hardware flow control (RTS/CTS) support in most configurations.
 - The PWRKEY pin toggles power on/off, so the driver only pulses it once
   during initialization to avoid toggling the module off.

--- a/src/modules/simcom/sim800l.toit
+++ b/src/modules/simcom/sim800l.toit
@@ -1,0 +1,108 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import gpio
+import log
+import uart
+
+import .simcom
+
+import ...base.at as at
+import ...base.base as cellular
+import ...base.cellular as cellular
+import ...base.service show CellularServiceProvider
+
+main:
+  service := SIM800LService
+  service.install
+
+// --------------------------------------------------------------------------
+
+class SIM800LService extends CellularServiceProvider:
+  constructor:
+    super "simcom/sim800l" --major=0 --minor=1 --patch=0
+
+  create-driver -> cellular.Cellular
+      --logger/log.Logger
+      --port/uart.Port
+      --rx/gpio.Pin?
+      --tx/gpio.Pin?
+      --rts/gpio.Pin?
+      --cts/gpio.Pin?
+      --power/gpio.Pin?
+      --reset/gpio.Pin?
+      --baud-rates/List?:
+    return SIM800L port logger
+        --pwrkey=power
+        --rst-pin=reset
+        --baud-rates=baud-rates
+
+/**
+Driver for SIM800L, GSM/GPRS modem.
+
+The $pwrkey pin corresponds to the PWRKEY pin of the SIM800L module.
+The $rst-pin corresponds to the RST pin.
+*/
+class SIM800L extends SimcomCellular:
+  pwrkey/gpio.Pin?
+  rst-pin/gpio.Pin?
+
+  constructor port/uart.Port logger/log.Logger
+      --.pwrkey=null
+      --.rst-pin=null
+      --baud-rates/List?:
+    super port
+        --logger=logger
+        --uart-baud-rates=baud-rates or [115_200]
+        --use-psm=false
+
+  network-name -> string:
+    return "cellular:sim800l"
+
+  on-connected_ session/at.Session:
+    // Enable multi-connection mode.
+    session.set "+CIPMUX" [1]
+    // Enable manual data receive mode.
+    session.set "+CIPRXGET" [1]
+    // Shut down any previous IP connection.
+    session.action "+CIPSHUT"
+    // Set APN.
+    session.set "+CSTT" [apn_]
+    // Bring up wireless connection (GPRS).
+    session.action "+CIICR" --timeout=(Duration --s=30)
+    // Get local IP address. AT+CIFSR returns just the IP without "OK",
+    // so we use a short timeout and accept whatever comes back.
+    result := session.action "+CIFSR" --timeout=(Duration --s=5) --no-check
+    logger.info "GPRS connected" --tags={"ip": result}
+
+  on-reset session/at.Session:
+    session.set "+CFUN" [1, 1]
+
+  powered-on_ := false
+
+  power-on -> none:
+    if powered-on_: return
+    powered-on_ = true
+    // PWRKEY pulse to turn on the module.
+    if pwrkey:
+      critical-do --no-respect-deadline:
+        pwrkey.set 1
+        sleep --ms=1100
+        pwrkey.set 0
+        sleep --ms=3000
+
+  power-off -> none:
+    if not pwrkey: return
+    // PWRKEY pulse to turn off (hold >650ms).
+    critical-do --no-respect-deadline:
+      pwrkey.set 1
+      sleep --ms=1500
+      pwrkey.set 0
+
+  reset -> none:
+    if not rst-pin: return
+    critical-do --no-respect-deadline:
+      rst-pin.set 0
+      sleep --ms=150
+      rst-pin.set 1

--- a/src/modules/simcom/sim800l.toit
+++ b/src/modules/simcom/sim800l.toit
@@ -14,12 +14,12 @@ import ...base.cellular as cellular
 import ...base.service show CellularServiceProvider
 
 main:
-  service := SIM800LService
+  service := Sim800lService
   service.install
 
 // --------------------------------------------------------------------------
 
-class SIM800LService extends CellularServiceProvider:
+class Sim800lService extends CellularServiceProvider:
   constructor:
     super "simcom/sim800l" --major=0 --minor=1 --patch=0
 
@@ -33,7 +33,7 @@ class SIM800LService extends CellularServiceProvider:
       --power/gpio.Pin?
       --reset/gpio.Pin?
       --baud-rates/List?:
-    return SIM800L port logger
+    return Sim800l port logger
         --pwrkey=power
         --rst-pin=reset
         --baud-rates=baud-rates
@@ -44,7 +44,7 @@ Driver for SIM800L, GSM/GPRS modem.
 The $pwrkey pin corresponds to the PWRKEY pin of the SIM800L module.
 The $rst-pin corresponds to the RST pin.
 */
-class SIM800L extends SimcomCellular:
+class Sim800l extends SimcomCellular:
   pwrkey/gpio.Pin?
   rst-pin/gpio.Pin?
 
@@ -107,7 +107,6 @@ class SIM800L extends SimcomCellular:
         pwrkey.set 1
         sleep --ms=1100
         pwrkey.set 0
-        sleep --ms=3000  // Wait for module to boot and send "RDY" URC.
 
   power-off -> none:
     if not pwrkey: return

--- a/src/modules/simcom/sim800l.toit
+++ b/src/modules/simcom/sim800l.toit
@@ -61,22 +61,36 @@ class SIM800L extends SimcomCellular:
     return "cellular:sim800l"
 
   on-connected_ session/at.Session:
-    // Enable multi-connection mode.
+    // AT Command Manual V1.09, Section 8.2.1 (CIPMUX):
+    // AT+CIPMUX=1 enables multi-IP connection (up to 6 connections, IDs 0-5).
+    // Must be set when state is IP INITIAL (before CIPSTART).
     session.set "+CIPMUX" [1]
-    // Enable manual data receive mode.
+    // AT Command Manual V1.09, Section 8.2.26 (CIPRXGET):
+    // AT+CIPRXGET=1 enables manual data receive mode.
+    // When data arrives, a "+CIPRXGET: 1,<id>" URC is sent instead of
+    // pushing raw data to the serial port. This avoids mixing binary
+    // data with AT command responses.
     session.set "+CIPRXGET" [1]
-    // Shut down any previous IP connection.
+    // AT Command Manual V1.09, Section 8.2.7 (CIPSHUT):
+    // Deactivates GPRS PDP context. Resets state to IP INITIAL.
     session.action "+CIPSHUT"
-    // Set APN.
+    // AT Command Manual V1.09, Section 8.2.9 (CSTT):
+    // AT+CSTT=<apn> starts task and sets APN. Valid only at IP INITIAL state.
+    // After this command, state changes to IP START.
     session.set "+CSTT" [apn_]
-    // Bring up wireless connection (GPRS).
+    // AT Command Manual V1.09, Section 8.2.10 (CIICR):
+    // Brings up wireless connection (GPRS or CSD). Max response time: 85s.
+    // State changes: IP START -> IP CONFIG -> IP GPRSACT.
     session.action "+CIICR" --timeout=(Duration --s=30)
-    // Get local IP address. AT+CIFSR returns just the IP without "OK",
-    // so we use a short timeout and accept whatever comes back.
+    // AT Command Manual V1.09, Section 8.2.11 (CIFSR):
+    // Gets local IP address. Response is just "<IP address>" without "OK".
+    // Only works after PDP context is activated (state IP GPRSACT or later).
     result := session.action "+CIFSR" --timeout=(Duration --s=5) --no-check
     logger.info "GPRS connected" --tags={"ip": result}
 
   on-reset session/at.Session:
+    // AT Command Manual V1.09, Section 3.2.42 (CFUN):
+    // AT+CFUN=1,1 sets full functionality and resets the module.
     session.set "+CFUN" [1, 1]
 
   powered-on_ := false
@@ -84,17 +98,21 @@ class SIM800L extends SimcomCellular:
   power-on -> none:
     if powered-on_: return
     powered-on_ = true
-    // PWRKEY pulse to turn on the module.
+    // SIM800L Hardware Design V1.00:
+    // Pull PWRKEY low for at least 1 second to turn on the module.
+    // The PWRKEY pin toggles power state (on<->off), so we only
+    // pulse it once to avoid turning the module off again.
     if pwrkey:
       critical-do --no-respect-deadline:
         pwrkey.set 1
         sleep --ms=1100
         pwrkey.set 0
-        sleep --ms=3000
+        sleep --ms=3000  // Wait for module to boot and send "RDY" URC.
 
   power-off -> none:
     if not pwrkey: return
-    // PWRKEY pulse to turn off (hold >650ms).
+    // SIM800L Hardware Design V1.00:
+    // Pull PWRKEY low for at least 650ms to turn off the module.
     critical-do --no-respect-deadline:
       pwrkey.set 1
       sleep --ms=1500
@@ -102,6 +120,8 @@ class SIM800L extends SimcomCellular:
 
   reset -> none:
     if not rst-pin: return
+    // SIM800L Hardware Design V1.00:
+    // Pull RST low for at least 105ms to perform a hard reset.
     critical-do --no-respect-deadline:
       rst-pin.set 0
       sleep --ms=150

--- a/src/modules/simcom/simcom.toit
+++ b/src/modules/simcom/simcom.toit
@@ -23,6 +23,8 @@ CONNECTED-STATE_  ::= 1 << 0
 READ-STATE_       ::= 1 << 1
 CLOSE-STATE_      ::= 1 << 2
 
+// AT Command Manual V1.09, Section 8.2.2: Max response time for CIPSTART
+// is 75 seconds in multi-IP state.
 TIMEOUT-CIPSTART ::= Duration --s=75
 TIMEOUT-CIPSEND  ::= Duration --s=10
 TIMEOUT-CIPRXGET ::= Duration --s=5
@@ -67,6 +69,9 @@ class Socket_:
     unreachable
 
 class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin implements tcp.Socket:
+  // AT Command Manual V1.09, Section 8.2.3: The data length which can be
+  // sent depends on network status. There are at most <size> bytes which
+  // can be sent at a time (max 1460).
   static MAX-SIZE_ ::= 1460
 
   peer-address/net.SocketAddress
@@ -80,9 +85,15 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
   constructor cellular/SimcomCellular id/int .peer-address:
     super cellular id
 
-    // CIPSTART returns OK first, then "<id>, CONNECT OK" when connected.
-    // Both are recognized as OK terminations, so the command completes
-    // on the first OK. The CONNECT OK arrives later and is ignored.
+    // AT Command Manual V1.09, Section 8.2.2 (CIPSTART):
+    // In multi-IP mode (CIPMUX=1):
+    //   AT+CIPSTART=<n>,<mode>,<address>,<port>
+    //   Response: OK (immediate), then <n>, CONNECT OK (async).
+    // Parameters:
+    //   <n>       0..5  Connection number
+    //   <mode>    "TCP" or "UDP"
+    //   <address> IP address or domain name (string)
+    //   <port>    Remote server port (string)
     socket-call: | session/at.Session |
       session.set "+CIPSTART" --timeout=TIMEOUT-CIPSTART [
         get-id_,
@@ -90,7 +101,7 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
         peer-address.ip.stringify,
         "$peer-address.port",
       ]
-    // Wait for the CONNECT OK response.
+    // Wait for the "<n>, CONNECT OK" async response.
     sleep --ms=3000
 
   local-address -> net.SocketAddress:
@@ -107,13 +118,17 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
     return in.read
 
   read_ -> ByteArray?:
+    // AT Command Manual V1.09, Section 8.2.26 (CIPRXGET):
+    // Mode 1: URC "+CIPRXGET: 1,<id>" signals data is available.
+    // Mode 2: AT+CIPRXGET=2,<id>,<reqlength>
+    //   Response: +CIPRXGET: 2,<id>,<reqlength>,<cnflength>\r\n<data>
+    //   <reqlength>  Requested bytes (1-1460)
+    //   <cnflength>  Confirmed bytes available (may be less; 0 = no data)
     while true:
       state := cellular_.wait-for-urc_: state_.wait-for READ-STATE_
       if state & CLOSE-STATE_ != 0:
         return null
       else if state & READ-STATE_ != 0:
-        // Response: +CIPRXGET: 2,<id>,<data_len>,<remaining_len>\r\n<data>
-        // Parsed as: [2, id, data_len, remaining, data]
         r := socket-call: | session/at.Session |
           session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, MAX-SIZE_]
         out := r.single
@@ -128,6 +143,10 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
     if to - from > MAX-SIZE_: to = from + MAX-SIZE_
     data = data.byte-slice from to
 
+    // AT Command Manual V1.09, Section 8.2.3 (CIPSEND):
+    // In multi-IP mode: AT+CIPSEND=<n>,<length>
+    // Module responds with ">" prompt, then we send data.
+    // Response: <n>, SEND OK (normal mode, CIPQSEND=0).
     e := catch --unwind=(: it is not UnavailableException):
       socket-call: | session/at.Session |
         session.set "+CIPSEND" [get-id_, data.byte-size]
@@ -152,6 +171,10 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
     // Do nothing.
 
   close:
+    // AT Command Manual V1.09, Section 8.2.6 (CIPCLOSE):
+    // In multi-IP mode: AT+CIPCLOSE=<id>[,<n>]
+    //   <n> 0=slow close (default), 1=quick close.
+    // Response: <id>, CLOSE OK
     if id_:
       id := id_
       closed_
@@ -182,6 +205,10 @@ class UdpSocket extends Socket_ implements udp.Socket:
     remote-address_ = address
     if not connected_:
       connected_ = true
+      // AT Command Manual V1.09, Section 8.2.2 (CIPSTART):
+      // AT+CIPSTART=<n>,"UDP",<address>,<port>
+      // Unlike "UDP SERVICE" on some modules, SIM800L requires a real
+      // remote address for UDP connections.
       socket-call: | session/at.Session |
         session.set "+CIPSTART" --timeout=TIMEOUT-CIPSTART [
           get-id_,
@@ -189,7 +216,7 @@ class UdpSocket extends Socket_ implements udp.Socket:
           address.ip.stringify,
           "$address.port",
         ]
-      // Wait for CONNECT OK.
+      // Wait for "<n>, CONNECT OK" async response.
       sleep --ms=3000
 
   write data/io.Data from/int=0 to/int=data.byte-size -> int:
@@ -275,17 +302,22 @@ abstract class SimcomCellular extends CellularBase:
       --uart-baud-rates=uart-baud-rates
       --use-psm=use-psm
 
-    // URC for data available (manual receive mode).
+    // AT Command Manual V1.09, Section 8.2.26 (CIPRXGET):
+    // URC "+CIPRXGET: 1,<id>" indicates data is available for connection <id>.
+    // Must be enabled with AT+CIPRXGET=1 before opening connections.
     at-session.register-urc "+CIPRXGET":: | args |
       if args[0] == 1:
-        // Data available notification.
         sockets_.get args[1]
             --if-present=: it.state_.set-state READ-STATE_
 
-    // URC for DNS resolution results.
+    // AT Command Manual V1.09, Section 8.2.14 (CDNSGIP):
+    // Async DNS resolution. AT+CDNSGIP=<domain> returns OK immediately,
+    // then sends URC:
+    //   Success: +CDNSGIP: 1,<domain name>,<IP1>[,<IP2>]
+    //   Failure: +CDNSGIP: 0,<dns error code>
+    //     Error codes: 3=NETWORK ERROR, 8=DNS COMMON ERROR.
     at-session.register-urc "+CDNSGIP":: | args |
       if args[0] == 1 and args.size >= 3:
-        // Success: +CDNSGIP: 1,"hostname","ip1"[,"ip2"]
         if resolve_: resolve_.set args[2]
       else:
         if resolve_: resolve_.set --exception "DNS resolution failed: $args"
@@ -296,42 +328,49 @@ abstract class SimcomCellular extends CellularBase:
       --data-marker='>'
       --command-delay=Duration --ms=20
 
-    session.add-ok-termination "SEND OK"
-    session.add-ok-termination "SHUT OK"
-    session.add-ok-termination "CLOSE OK"
-    session.add-ok-termination "CONNECT OK"
+    // SIM800L non-standard termination strings.
+    // In multi-IP mode these are prefixed with "<id>, " (e.g. "0, SEND OK").
+    // The AT session's is-terminating_ handles the prefix stripping.
+    session.add-ok-termination "SEND OK"    // AT Command Manual Section 8.2.3.
+    session.add-ok-termination "SHUT OK"    // AT Command Manual Section 8.2.7.
+    session.add-ok-termination "CLOSE OK"   // AT Command Manual Section 8.2.6.
+    session.add-ok-termination "CONNECT OK" // AT Command Manual Section 8.2.2.
     session.add-error-termination "SEND FAIL"
     session.add-error-termination "+CME ERROR"
     session.add-error-termination "+CMS ERROR"
 
-    // CIPRXGET response parser.
-    // Response format: +CIPRXGET: <mode>,<id>,<data_len>,<remaining_len>\r\n<data>
+    // AT Command Manual V1.09, Section 8.2.26 (CIPRXGET) response parser.
+    // Mode 1 (URC):  +CIPRXGET: 1,<id>
+    // Mode 2 (read): +CIPRXGET: 2,<id>,<reqlength>,<cnflength>\r\n<data>
+    //   <reqlength>  Requested bytes (1-1460)
+    //   <cnflength>  Confirmed bytes (may be less; 0 = no data)
+    // Mode 4 (query): +CIPRXGET: 4,<id>,<cnflength>
     session.add-response-parser "+CIPRXGET" :: | reader/io.Reader |
       line := reader.read-bytes-up-to '\r'
       parts := at.parse-response line
       if parts[0] == 1:
-        // Data notification URC: +CIPRXGET: 1,<id>
         parts
       else if parts[0] == 2:
-        // Data read response: +CIPRXGET: 2,<id>,<data_len>,<remaining_len>
         data-len := parts[2]
         if data-len > 0:
           reader.skip 1  // Skip '\n'.
           parts.add (reader.read-bytes data-len)
         parts
       else if parts[0] == 4:
-        // Query unread data: +CIPRXGET: 4,<id>,<unread_len>
         parts
       else:
         parts
 
-    // CCID response parser (ICCID is too large for int).
+    // AT Command Manual V1.09, Section 6.2.23 (CCID): Show ICCID.
+    // Response is a raw number too large for 64-bit int, so custom parser
+    // reads it as a string.
     session.add-response-parser "+CCID" :: | reader/io.Reader |
       iccid := reader.read-string-up-to session.s3
       [iccid.trim]
 
-    // CIFSR doesn't have a "+CIFSR:" prefix - it just returns the IP address.
-    // This is handled by the AT session as an unrecognized response line.
+    // AT Command Manual V1.09, Section 8.2.11 (CIFSR): Get local IP address.
+    // Response is just "<IP address>" with no "+CIFSR:" prefix and no "OK".
+    // Handled by the AT session as an unrecognized response line.
 
     return session
 
@@ -339,6 +378,10 @@ abstract class SimcomCellular extends CellularBase:
     return true
 
   close:
+    // AT Command Manual V1.09:
+    // Section 8.2.7 (CIPSHUT): Deactivate GPRS PDP context and close all
+    //   connections. Response: SHUT OK. Max response time: 65 seconds.
+    // Section 6.2.2 (CPOWD): Power off. AT+CPOWD=1 sends "NORMAL POWER DOWN".
     try:
       sockets_.values.do: it.closed_
       catch: with-timeout --ms=3_000: at_.do: | session/at.Session |
@@ -361,7 +404,9 @@ abstract class SimcomCellular extends CellularBase:
     failed-to-connect = true
 
     done := monitor.Latch
-    // SIM800L only supports GSM: +CREG and +CGREG.
+    // SIM800L only supports GSM/GPRS, so we use +CGREG (GPRS registration)
+    // instead of +CEREG (LTE). See AT Command Manual Section 7.2.10.
+    // +CGREG URC states: 1=registered home, 5=registered roaming.
     registrations := { "+CGREG" }
     failed := {}
 
@@ -408,6 +453,8 @@ abstract class SimcomCellular extends CellularBase:
       wait-for-sim_ session
 
   set-baud-rate_ session/at.Session baud-rate/int:
+    // AT Command Manual V1.09, Section 2.2.41 (IPR): Set TE-TA fixed local rate.
+    // "&W" saves the profile to NVRAM.
     session.action "+IPR=$baud-rate;&W"
     uart_.baud-rate = baud-rate
     sleep --ms=100
@@ -473,7 +520,8 @@ class SimcomInterface_ extends CloseableNetwork implements net.Interface:
     throw "UNIMPLEMENTED"
 
   socket-id_ -> int:
-    // SIM800L supports 6 connections (IDs 0-5) in multi-connection mode.
+    // AT Command Manual V1.09, Section 8.2.2 (CIPSTART):
+    // <n> 0..5, connection number in multi-IP mode.
     6.repeat:
       if not cellular_.sockets_.contains it: return it
     throw

--- a/src/modules/simcom/simcom.toit
+++ b/src/modules/simcom/simcom.toit
@@ -1,0 +1,489 @@
+// Copyright (C) 2026 Toit contributors.
+// Use of this source code is governed by an MIT-style license that can be
+// found in the LICENSE file.
+
+import io
+import net
+import net.udp as udp
+import net.tcp as tcp
+import log
+import monitor
+import uart
+
+import system.base.network show CloseableNetwork
+
+import monitor
+
+import ...base.at as at
+import ...base.base
+import ...base.cellular
+import ...base.exceptions
+
+CONNECTED-STATE_  ::= 1 << 0
+READ-STATE_       ::= 1 << 1
+CLOSE-STATE_      ::= 1 << 2
+
+TIMEOUT-CIPSTART ::= Duration --s=75
+TIMEOUT-CIPSEND  ::= Duration --s=10
+TIMEOUT-CIPRXGET ::= Duration --s=5
+
+monitor SocketState_:
+  state_/int := 0
+  dirty_/bool := false
+
+  wait-for state --error-state=CLOSE-STATE_:
+    bits := (state | error-state)
+    await: state_ & bits != 0
+    dirty_ = false
+    return state_ & bits
+
+  set-state state:
+    dirty_ = true
+    state_ |= state
+
+  clear state:
+    if not dirty_:
+      state_ &= ~state
+
+class Socket_:
+  state_ ::= SocketState_
+  cellular_/SimcomCellular
+  id_/int? := ?
+
+  constructor .cellular_ .id_:
+
+  closed_:
+    state_.set-state CLOSE-STATE_
+
+  get-id_ -> int:
+    if not id_: throw "socket is closed"
+    return id_
+
+  socket-call [block]:
+    cellular_.at_.do: | session/at.Session |
+      e := catch:
+        return block.call session
+      throw (UnknownException "SOCKET ERROR: $e")
+    unreachable
+
+class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin implements tcp.Socket:
+  static MAX-SIZE_ ::= 1460
+
+  peer-address/net.SocketAddress
+
+  no-delay -> bool:
+    return false
+
+  no-delay= value/bool -> none:
+    // Not supported.
+
+  constructor cellular/SimcomCellular id/int .peer-address:
+    super cellular id
+
+    // CIPSTART returns OK first, then "<id>, CONNECT OK" when connected.
+    // Both are recognized as OK terminations, so the command completes
+    // on the first OK. The CONNECT OK arrives later and is ignored.
+    socket-call: | session/at.Session |
+      session.set "+CIPSTART" --timeout=TIMEOUT-CIPSTART [
+        get-id_,
+        "TCP",
+        peer-address.ip.stringify,
+        "$peer-address.port",
+      ]
+    // Wait for the CONNECT OK response.
+    sleep --ms=3000
+
+  local-address -> net.SocketAddress:
+    return net.SocketAddress
+      net.IpAddress.parse "127.0.0.1"
+      0
+
+  connect_:
+    // On SIM800L, the connection is established after CIPSTART returns OK.
+    // The "<id>, CONNECT OK" notification is not a standard URC and is
+    // handled by the sleep in the constructor.
+
+  read -> ByteArray?:
+    return in.read
+
+  read_ -> ByteArray?:
+    while true:
+      state := cellular_.wait-for-urc_: state_.wait-for READ-STATE_
+      if state & CLOSE-STATE_ != 0:
+        return null
+      else if state & READ-STATE_ != 0:
+        // Response: +CIPRXGET: 2,<id>,<data_len>,<remaining_len>\r\n<data>
+        // Parsed as: [2, id, data_len, remaining, data]
+        r := socket-call: | session/at.Session |
+          session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, MAX-SIZE_]
+        out := r.single
+        data-len := out[2]
+        if data-len > 0: return out[4]
+        state_.clear READ-STATE_
+      else:
+        throw "SOCKET ERROR"
+
+  try-write_ data/io.Data from/int=0 to/int=data.byte-size -> int:
+    if to == from: return 0
+    if to - from > MAX-SIZE_: to = from + MAX-SIZE_
+    data = data.byte-slice from to
+
+    e := catch --unwind=(: it is not UnavailableException):
+      socket-call: | session/at.Session |
+        session.set "+CIPSEND" [get-id_, data.byte-size]
+            --timeout=TIMEOUT-CIPSEND
+            --data=data
+      yield
+      return data.byte-size
+
+    sleep --ms=100
+    return 0
+
+  write data/io.Data from/int=0 to/int=data.byte-size -> int:
+    return out.try-write data from to
+
+  close-write:
+    out.close
+
+  close-reader_:
+    // Do nothing.
+
+  close-writer_:
+    // Do nothing.
+
+  close:
+    if id_:
+      id := id_
+      closed_
+      id_ = null
+      try:
+        cellular_.at_.do: | session/at.Session |
+          if not session.is-closed:
+            session.set "+CIPCLOSE" [id]
+      finally:
+        cellular_.sockets_.remove id
+
+  mtu -> int:
+    return 1500
+
+class UdpSocket extends Socket_ implements udp.Socket:
+  remote-address_/net.SocketAddress? := null
+  connected_ := false
+
+  constructor cellular/SimcomCellular id/int:
+    super cellular id
+
+  local-address -> net.SocketAddress:
+    return net.SocketAddress
+      net.IpAddress.parse "127.0.0.1"
+      0
+
+  connect address/net.SocketAddress:
+    remote-address_ = address
+    if not connected_:
+      connected_ = true
+      socket-call: | session/at.Session |
+        session.set "+CIPSTART" --timeout=TIMEOUT-CIPSTART [
+          get-id_,
+          "UDP",
+          address.ip.stringify,
+          "$address.port",
+        ]
+      // Wait for CONNECT OK.
+      sleep --ms=3000
+
+  write data/io.Data from/int=0 to/int=data.byte-size -> int:
+    if not remote-address_: throw "NOT_CONNECTED"
+    if from != 0 or to != data.byte-size: data = data.byte-slice from to
+    return send_ remote-address_ data
+
+  read -> ByteArray?:
+    msg := receive
+    if not msg: return null
+    return msg.data
+
+  send datagram/udp.Datagram -> int:
+    return send_ datagram.address datagram.data
+
+  send_ address/net.SocketAddress data/io.Data -> int:
+    if data.byte-size > mtu: throw "PAYLOAD_TO_LARGE"
+    socket-call: | session/at.Session |
+      // In multi-connection mode, UDP send is via CIPSEND with the
+      // connection id.
+      session.set "+CIPSEND" [get-id_, data.byte-size]
+          --timeout=TIMEOUT-CIPSEND
+          --data=data
+    return data.byte-size
+
+  receive -> udp.Datagram?:
+    while true:
+      state := state_.wait-for READ-STATE_
+      if state & CLOSE-STATE_ != 0:
+        return null
+      else if state & READ-STATE_ != 0:
+        // Response: +CIPRXGET: 2,<id>,<data_len>,<remaining>\r\n<data>
+        // Parsed as: [2, id, data_len, remaining, data]
+        res := socket-call: | session/at.Session |
+          (session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, 1460]).single
+        data-len := res[2]
+        if data-len > 0:
+          return udp.Datagram
+            res[4]
+            remote-address_ or (net.SocketAddress (net.IpAddress.parse "0.0.0.0") 0)
+        state_.clear READ-STATE_
+      else:
+        throw "SOCKET ERROR"
+
+  close:
+    if id_:
+      id := id_
+      id_ = null
+      try:
+        cellular_.at_.do: | session/at.Session |
+          if not session.is-closed:
+            session.set "+CIPCLOSE" [id]
+      finally:
+        closed_
+        cellular_.sockets_.remove id
+
+  mtu -> int:
+    return 1460
+
+  broadcast -> bool: return false
+
+  broadcast= value/bool: throw "BROADCAST_UNSUPPORTED"
+
+/**
+Base driver for SIMCom cellular modules (GSM/GPRS).
+*/
+abstract class SimcomCellular extends CellularBase:
+  apn_/string := ""
+  resolve_/monitor.Latch? := null
+
+  abstract on-reset session/at.Session
+
+  constructor
+      uart/uart.Port
+      --logger/log.Logger
+      --uart-baud-rates/List
+      --use-psm/bool:
+    at-session := configure-at_ uart logger
+
+    super uart at-session
+      --logger=logger
+      --constants=SimcomConstants_
+      --uart-baud-rates=uart-baud-rates
+      --use-psm=use-psm
+
+    // URC for data available (manual receive mode).
+    at-session.register-urc "+CIPRXGET":: | args |
+      if args[0] == 1:
+        // Data available notification.
+        sockets_.get args[1]
+            --if-present=: it.state_.set-state READ-STATE_
+
+    // URC for DNS resolution results.
+    at-session.register-urc "+CDNSGIP":: | args |
+      if args[0] == 1 and args.size >= 3:
+        // Success: +CDNSGIP: 1,"hostname","ip1"[,"ip2"]
+        if resolve_: resolve_.set args[2]
+      else:
+        if resolve_: resolve_.set --exception "DNS resolution failed: $args"
+
+  static configure-at_ uart/uart.Port logger/log.Logger -> at.Session:
+    session := at.Session uart.in uart.out
+      --logger=logger
+      --data-marker='>'
+      --command-delay=Duration --ms=20
+
+    session.add-ok-termination "SEND OK"
+    session.add-ok-termination "SHUT OK"
+    session.add-ok-termination "CLOSE OK"
+    session.add-ok-termination "CONNECT OK"
+    session.add-error-termination "SEND FAIL"
+    session.add-error-termination "+CME ERROR"
+    session.add-error-termination "+CMS ERROR"
+
+    // CIPRXGET response parser.
+    // Response format: +CIPRXGET: <mode>,<id>,<data_len>,<remaining_len>\r\n<data>
+    session.add-response-parser "+CIPRXGET" :: | reader/io.Reader |
+      line := reader.read-bytes-up-to '\r'
+      parts := at.parse-response line
+      if parts[0] == 1:
+        // Data notification URC: +CIPRXGET: 1,<id>
+        parts
+      else if parts[0] == 2:
+        // Data read response: +CIPRXGET: 2,<id>,<data_len>,<remaining_len>
+        data-len := parts[2]
+        if data-len > 0:
+          reader.skip 1  // Skip '\n'.
+          parts.add (reader.read-bytes data-len)
+        parts
+      else if parts[0] == 4:
+        // Query unread data: +CIPRXGET: 4,<id>,<unread_len>
+        parts
+      else:
+        parts
+
+    // CCID response parser (ICCID is too large for int).
+    session.add-response-parser "+CCID" :: | reader/io.Reader |
+      iccid := reader.read-string-up-to session.s3
+      [iccid.trim]
+
+    // CIFSR doesn't have a "+CIFSR:" prefix - it just returns the IP address.
+    // This is handled by the AT session as an unrecognized response line.
+
+    return session
+
+  support-gsm_ -> bool:
+    return true
+
+  close:
+    try:
+      sockets_.values.do: it.closed_
+      catch: with-timeout --ms=3_000: at_.do: | session/at.Session |
+        if not session.is-closed:
+          session.action "+CIPSHUT"
+          session.set "+CPOWD" [1]
+    finally:
+      at-session_.close
+      uart_.close
+
+  iccid:
+    r := at_.do: it.action "+CCID"
+    return r.last[0]
+
+  /**
+  Overrides the base connect to use only GSM registration commands.
+  The SIM800L doesn't support LTE (+CEREG).
+  */
+  connect_ session/at.Session --operator/Operator?=null --psm/bool -> none:
+    failed-to-connect = true
+
+    done := monitor.Latch
+    // SIM800L only supports GSM: +CREG and +CGREG.
+    registrations := { "+CGREG" }
+    failed := {}
+
+    registrations.do: | command/string |
+      session.register-urc command:: | args |
+        state := args.first
+        if state == 1 or state == 5:
+          failed.remove command
+          done.set command
+        else if state == 3 or state == 80:
+          failed.add command
+          error := state == 3 ? REGISTRATION-DENIED-ERROR : "connection lost"
+          if failed.size == registrations.size: done.set --exception error
+
+    try:
+      // Enable registration events.
+      registrations.do: session.set it [2]
+
+      if not psm:
+        command := operator
+            ? COPS.manual operator.op --rat=operator.rat
+            : COPS.automatic
+        send-abortable_ session command
+
+      wait-for-urc_ --session=session:
+        done.get
+
+    finally:
+      registrations.do: session.unregister-urc it
+
+    on-connected_ session
+    failed-to-connect = false
+
+  wait-for-ready_ session/at.Session:
+    while true:
+      power-on
+      if select-baud_ session: break
+
+  configure apn/string --bands/List?=null --rats/List?=null:
+    apn_ = apn
+    // On the SIM800L, the APN is set via AT+CSTT during on-connected_,
+    // not via AT+CGDCONT. Just store it and wait for the SIM.
+    at_.do: | session/at.Session |
+      wait-for-sim_ session
+
+  set-baud-rate_ session/at.Session baud-rate/int:
+    session.action "+IPR=$baud-rate;&W"
+    uart_.baud-rate = baud-rate
+    sleep --ms=100
+
+  network-interface -> net.Interface:
+    return SimcomInterface_ network-name this
+
+  /**
+  Called after network registration succeeds.
+  Sets up GPRS bearer and multi-connection mode.
+  */
+  abstract on-connected_ session/at.Session
+
+class SimcomConstants_ implements Constants:
+  RatCatM1 -> int?: return null
+
+class SimcomInterface_ extends CloseableNetwork implements net.Interface:
+  name/string
+  cellular_/SimcomCellular
+  resolve-mutex_ ::= monitor.Mutex
+
+  constructor .name .cellular_:
+
+  resolve host/string -> List:
+    catch:
+      return [net.IpAddress.parse host]
+
+    // DNS resolution is async: AT+CDNSGIP returns OK immediately,
+    // then sends a +CDNSGIP URC with the result.
+    resolve-mutex_.do:
+      cellular_.resolve_ = monitor.Latch
+      try:
+        cellular_.at_.do: | session/at.Session |
+          session.set "+CDNSGIP" --timeout=(Duration --s=10) [host]
+        cellular_.wait-for-urc_:
+          result := cellular_.resolve_.get
+          return [net.IpAddress.parse result]
+      finally:
+        cellular_.resolve_ = null
+    unreachable
+
+  udp-open -> udp.Socket:
+    return udp-open --port=null
+
+  udp-open --port/int? -> udp.Socket:
+    id := socket-id_
+    socket := UdpSocket cellular_ id
+    cellular_.sockets_.update id --if-absent=(: socket): throw "socket already exists"
+    return socket
+
+  tcp-connect host/string port/int -> tcp.Socket:
+    ips := resolve host
+    return tcp-connect
+        net.SocketAddress ips[0] port
+
+  tcp-connect address/net.SocketAddress -> tcp.Socket:
+    id := socket-id_
+    socket := TcpSocket cellular_ id address
+    cellular_.sockets_.update id --if-absent=(: socket): throw "socket already exists"
+    return socket
+
+  tcp-listen port/int -> tcp.ServerSocket:
+    throw "UNIMPLEMENTED"
+
+  socket-id_ -> int:
+    // SIM800L supports 6 connections (IDs 0-5) in multi-connection mode.
+    6.repeat:
+      if not cellular_.sockets_.contains it: return it
+    throw
+      ResourceExhaustedException "no more sockets available"
+
+  address -> net.IpAddress:
+    unreachable
+
+  is-closed -> bool:
+    return false
+
+  close_:
+    // Nothing to clean up.

--- a/src/modules/simcom/simcom.toit
+++ b/src/modules/simcom/simcom.toit
@@ -85,15 +85,22 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
   constructor cellular/SimcomCellular id/int .peer-address:
     super cellular id
 
+  local-address -> net.SocketAddress:
+    return net.SocketAddress
+      net.IpAddress.parse "127.0.0.1"
+      0
+
+  /**
+  Sends CIPSTART and waits for the async CONNECT OK response.
+
+  Must be called after the socket is registered in the socket map so
+    that the on-unhandled-line callback can find it.
+  */
+  connect_:
     // AT Command Manual V1.09, Section 8.2.2 (CIPSTART):
     // In multi-IP mode (CIPMUX=1):
     //   AT+CIPSTART=<n>,<mode>,<address>,<port>
     //   Response: OK (immediate), then <n>, CONNECT OK (async).
-    // Parameters:
-    //   <n>       0..5  Connection number
-    //   <mode>    "TCP" or "UDP"
-    //   <address> IP address or domain name (string)
-    //   <port>    Remote server port (string)
     socket-call: | session/at.Session |
       session.set "+CIPSTART" --timeout=TIMEOUT-CIPSTART [
         get-id_,
@@ -101,18 +108,9 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
         peer-address.ip.stringify,
         "$peer-address.port",
       ]
-    // Wait for the "<n>, CONNECT OK" async response.
-    sleep --ms=3000
-
-  local-address -> net.SocketAddress:
-    return net.SocketAddress
-      net.IpAddress.parse "127.0.0.1"
-      0
-
-  connect_:
-    // On SIM800L, the connection is established after CIPSTART returns OK.
-    // The "<id>, CONNECT OK" notification is not a standard URC and is
-    // handled by the sleep in the constructor.
+    // Wait for the async "<n>, CONNECT OK" response, dispatched by
+    // the on-unhandled-line callback.
+    cellular_.wait-for-urc_: state_.wait-for CONNECTED-STATE_
 
   read -> ByteArray?:
     return in.read
@@ -131,9 +129,21 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
       else if state & READ-STATE_ != 0:
         r := socket-call: | session/at.Session |
           session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, MAX-SIZE_]
-        out := r.single
-        data-len := out[2]
-        if data-len > 0: return out[4]
+        // The response may include mode 1 URCs for other connections
+        // that arrived during the command. Dispatch them and find
+        // the mode 2 data response.
+        data-response := null
+        r.responses.do: | resp |
+          if resp[0] == 1:
+            cellular_.sockets_.get resp[1]
+                --if-present=: it.state_.set-state READ-STATE_
+          else if resp[0] == 2:
+            data-response = resp
+        if not data-response:
+          state_.clear READ-STATE_
+          continue
+        data-len := data-response[2]
+        if data-len > 0: return data-response[4]
         state_.clear READ-STATE_
       else:
         throw "SOCKET ERROR"
@@ -147,7 +157,7 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
     // In multi-IP mode: AT+CIPSEND=<n>,<length>
     // Module responds with ">" prompt, then we send data.
     // Response: <n>, SEND OK (normal mode, CIPQSEND=0).
-    e := catch --unwind=(: it is not UnavailableException):
+    catch --unwind=(: it is not UnavailableException):
       socket-call: | session/at.Session |
         session.set "+CIPSEND" [get-id_, data.byte-size]
             --timeout=TIMEOUT-CIPSEND
@@ -180,13 +190,18 @@ class TcpSocket extends Socket_ with io.CloseableInMixin io.CloseableOutMixin im
       closed_
       id_ = null
       try:
-        cellular_.at_.do: | session/at.Session |
-          if not session.is-closed:
-            session.set "+CIPCLOSE" [id]
+        // The connection may already be closed by the remote side
+        // ("<n>, CLOSED" notification), so tolerate errors here.
+        catch:
+          cellular_.at_.do: | session/at.Session |
+            if not session.is-closed:
+              session.set "+CIPCLOSE" [id]
       finally:
         cellular_.sockets_.remove id
 
   mtu -> int:
+    // Standard IP MTU (1500). The per-send limit MAX-SIZE_ (1460) is
+    // lower because it accounts for TCP/IP header overhead.
     return 1500
 
 class UdpSocket extends Socket_ implements udp.Socket:
@@ -216,8 +231,8 @@ class UdpSocket extends Socket_ implements udp.Socket:
           address.ip.stringify,
           "$address.port",
         ]
-      // Wait for "<n>, CONNECT OK" async response.
-      sleep --ms=3000
+      // Wait for the async "<n>, CONNECT OK" response.
+      cellular_.wait-for-urc_: state_.wait-for CONNECTED-STATE_
 
   write data/io.Data from/int=0 to/int=data.byte-size -> int:
     if not remote-address_: throw "NOT_CONNECTED"
@@ -249,13 +264,23 @@ class UdpSocket extends Socket_ implements udp.Socket:
         return null
       else if state & READ-STATE_ != 0:
         // Response: +CIPRXGET: 2,<id>,<data_len>,<remaining>\r\n<data>
-        // Parsed as: [2, id, data_len, remaining, data]
-        res := socket-call: | session/at.Session |
-          (session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, 1460]).single
-        data-len := res[2]
+        // May also include mode 1 URCs for other connections.
+        r := socket-call: | session/at.Session |
+          session.set "+CIPRXGET" --timeout=TIMEOUT-CIPRXGET [2, get-id_, 1460]
+        data-response := null
+        r.responses.do: | resp |
+          if resp[0] == 1:
+            cellular_.sockets_.get resp[1]
+                --if-present=: it.state_.set-state READ-STATE_
+          else if resp[0] == 2:
+            data-response = resp
+        if not data-response:
+          state_.clear READ-STATE_
+          continue
+        data-len := data-response[2]
         if data-len > 0:
           return udp.Datagram
-            res[4]
+            data-response[4]
             remote-address_ or (net.SocketAddress (net.IpAddress.parse "0.0.0.0") 0)
         state_.clear READ-STATE_
       else:
@@ -266,9 +291,10 @@ class UdpSocket extends Socket_ implements udp.Socket:
       id := id_
       id_ = null
       try:
-        cellular_.at_.do: | session/at.Session |
-          if not session.is-closed:
-            session.set "+CIPCLOSE" [id]
+        catch:
+          cellular_.at_.do: | session/at.Session |
+            if not session.is-closed:
+              session.set "+CIPCLOSE" [id]
       finally:
         closed_
         cellular_.sockets_.remove id
@@ -322,6 +348,14 @@ abstract class SimcomCellular extends CellularBase:
       else:
         if resolve_: resolve_.set --exception "DNS resolution failed: $args"
 
+    // AT Command Manual V1.09, Section 8.2.2 (CIPSTART):
+    // In multi-IP mode, CIPSTART returns OK immediately, then sends
+    // "<n>, CONNECT OK" or "<n>, CONNECT FAIL" asynchronously. These
+    // are not URCs (no "+" prefix), so we handle them via the
+    // unhandled-line callback.
+    at-session.on-unhandled-line= :: | line/string |
+      handle-unhandled-line_ line  // Returns true if handled.
+
   static configure-at_ uart/uart.Port logger/log.Logger -> at.Session:
     session := at.Session uart.in uart.out
       --logger=logger
@@ -334,7 +368,9 @@ abstract class SimcomCellular extends CellularBase:
     session.add-ok-termination "SEND OK"    // AT Command Manual Section 8.2.3.
     session.add-ok-termination "SHUT OK"    // AT Command Manual Section 8.2.7.
     session.add-ok-termination "CLOSE OK"   // AT Command Manual Section 8.2.6.
-    session.add-ok-termination "CONNECT OK" // AT Command Manual Section 8.2.2.
+    // CONNECT OK is handled by the on-unhandled-line callback (not as a
+    // termination) because it arrives asynchronously and could interfere
+    // with other active commands via is-prefixed-termination_.
     session.add-error-termination "SEND FAIL"
     session.add-error-termination "+CME ERROR"
     session.add-error-termination "+CMS ERROR"
@@ -362,8 +398,9 @@ abstract class SimcomCellular extends CellularBase:
         parts
 
     // AT Command Manual V1.09, Section 6.2.23 (CCID): Show ICCID.
-    // Response is a raw number too large for 64-bit int, so custom parser
-    // reads it as a string.
+    // ICCIDs are 19-20 digits. A 64-bit signed int holds up to ~9.2×10^18
+    // (19 digits), so 20-digit ICCIDs overflow. The custom parser reads the
+    // value as a string to avoid inconsistent int parsing.
     session.add-response-parser "+CCID" :: | reader/io.Reader |
       iccid := reader.read-string-up-to session.s3
       [iccid.trim]
@@ -376,6 +413,32 @@ abstract class SimcomCellular extends CellularBase:
 
   support-gsm_ -> bool:
     return true
+
+  /**
+  Handles asynchronous non-URC lines like "<n>, CONNECT OK".
+
+  Returns true if the line was recognized and handled, false otherwise.
+    This is called both when no command is active and during active
+    commands to prevent stray lines from corrupting command responses.
+  */
+  handle-unhandled-line_ line/string -> bool:
+    comma := line.index-of ", "
+    if comma < 0: return false
+    id := int.parse line[..comma] --if-error=: return false
+    suffix := line[comma + 2..]
+    if suffix == "CONNECT OK":
+      sockets_.get id
+          --if-present=: it.state_.set-state CONNECTED-STATE_
+      return true
+    else if suffix == "CONNECT FAIL" or suffix == "ALREADY CONNECT":
+      sockets_.get id
+          --if-present=: it.state_.set-state CLOSE-STATE_
+      return true
+    else if suffix == "CLOSED":
+      sockets_.get id
+          --if-present=: it.state_.set-state CLOSE-STATE_
+      return true
+    return false
 
   close:
     // AT Command Manual V1.09:
@@ -514,6 +577,7 @@ class SimcomInterface_ extends CloseableNetwork implements net.Interface:
     id := socket-id_
     socket := TcpSocket cellular_ id address
     cellular_.sockets_.update id --if-absent=(: socket): throw "socket already exists"
+    socket.connect_
     return socket
 
   tcp-listen port/int -> tcp.ServerSocket:


### PR DESCRIPTION
Add support for the SIMCom SIM800L 2G module, following the existing driver architecture (Quectel, Sequans, u-blox).

Key implementation details:
- GSM/GPRS only: uses +CGREG instead of +CEREG for registration
- SIMCom TCP/IP stack: AT+CSTT/CIICR/CIFSR for GPRS bearer, AT+CIPSTART/CIPSEND/CIPRXGET for sockets
- Manual data receive mode (AT+CIPRXGET=1) for clean AT parsing
- Async DNS via AT+CDNSGIP
- Multi-connection mode (up to 6 simultaneous sockets)

Also extends the AT session to support prefixed terminations (e.g. "0, SEND OK") used by SIM800L in multi-connection mode.